### PR TITLE
Update json dependency to greater than 1.8

### DIFF
--- a/openpay.gemspec
+++ b/openpay.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib','lib/openpay','openpay','.']
 
   spec.add_runtime_dependency 'rest-client'  , '~>2.0'
-  spec.add_runtime_dependency 'json', '~> 1.8'
+  spec.add_runtime_dependency 'json', '>= 1.8'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
## Summary 

OpenPay's dependency on `json 1.8.6` is out of date. The current version is `json 2.1.0` My company (Branch International) is dependent on the up-to-date version of `json`, which means that we can't use the `openpay-ruby` gem. 

This PR updates the dependency on json to be `>= 1.8`, in order to prevent this issue. 

